### PR TITLE
Fix Flask startup hook

### DIFF
--- a/app.py
+++ b/app.py
@@ -34,7 +34,7 @@ def init_db():
     )
     db.commit()
 
-@app.before_first_request
+@app.before_serving
 def setup():
     init_db()
 


### PR DESCRIPTION
## Summary
- use `before_serving` instead of deprecated `before_first_request`

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684180eb267c832ea9ed97bebdd0682c